### PR TITLE
Fixed wrong CGSession used with the events posted (a case of multiple users)

### DIFF
--- a/Sources/SendKeysLib/KeyPresser.swift
+++ b/Sources/SendKeysLib/KeyPresser.swift
@@ -21,12 +21,12 @@ public class KeyPresser {
         let keyDownEvent = try! createKeyEvent(key: key, modifiers: modifiers, keyDown: true)
 
         if self.application == nil {
-            keyDownEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+            keyDownEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         } else {
             if #available(OSX 10.11, *) {
                 keyDownEvent?.postToPid(self.application!.processIdentifier)
             } else {
-                keyDownEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+                keyDownEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
             }
         }
 
@@ -37,12 +37,12 @@ public class KeyPresser {
         let keyUpEvent = try! createKeyEvent(key: key, modifiers: modifiers, keyDown: false)
 
         if self.application == nil {
-            keyUpEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+            keyUpEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         } else {
             if #available(OSX 10.11, *) {
                 keyUpEvent?.postToPid(self.application!.processIdentifier)
             } else {
-                keyUpEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+                keyUpEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
             }
         }
 
@@ -54,12 +54,12 @@ public class KeyPresser {
             key: key, modifiers: modifiers, keyDown: false, parentEventSource: CGEventSource(event: event))
 
         if self.application == nil {
-            keyUpEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+            keyUpEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         } else {
             if #available(OSX 10.11, *) {
                 keyUpEvent?.postToPid(self.application!.processIdentifier)
             } else {
-                keyUpEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+                keyUpEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
             }
         }
 

--- a/Sources/SendKeysLib/MouseController.swift
+++ b/Sources/SendKeysLib/MouseController.swift
@@ -67,13 +67,13 @@ class MouseController {
             mouseEventSource: nil, mouseType: downMouseType, mouseCursorPosition: resolvedLocation, mouseButton: button)
         downEvent?.setIntegerValueField(.mouseEventClickState, value: Int64(clickCount))
         downEvent?.flags = flags
-        downEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+        downEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         let eventSource = CGEventSource(event: downEvent)
 
         let upEvent = CGEvent(
             mouseEventSource: eventSource, mouseType: upMouseType, mouseCursorPosition: resolvedLocation,
             mouseButton: button)
-        upEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+        upEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
     }
 
     func down(_ location: CGPoint?, button: CGMouseButton, flags: CGEventFlags) {
@@ -83,7 +83,7 @@ class MouseController {
         let downEvent = CGEvent(
             mouseEventSource: nil, mouseType: downMouseType, mouseCursorPosition: resolvedLocation, mouseButton: button)
         downEvent?.flags = flags
-        downEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+        downEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
 
         downButtons.insert(button)
     }
@@ -95,7 +95,7 @@ class MouseController {
         let upEvent = CGEvent(
             mouseEventSource: nil, mouseType: upMouseType, mouseCursorPosition: resolvedLocation,
             mouseButton: button)
-        upEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+        upEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         downButtons.remove(button)
     }
 
@@ -118,7 +118,7 @@ class MouseController {
                 mouseEventSource: nil, mouseType: downMouseType, mouseCursorPosition: resolvedStart, mouseButton: button
             )
             downEvent?.flags = flags
-            downEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+            downEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
             eventSource = CGEventSource(event: downEvent)
         }
 
@@ -127,7 +127,7 @@ class MouseController {
         if !downButtons.contains(button) {
             let upEvent = CGEvent(
                 mouseEventSource: eventSource, mouseType: upMouseType, mouseCursorPosition: end, mouseButton: button)
-            upEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+            upEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
         }
     }
 
@@ -188,7 +188,7 @@ class MouseController {
             event?.setIntegerValueField(field, value: Int64(amount * -1))
             event?.flags = flags
 
-            event?.post(tap: CGEventTapLocation.cghidEventTap)
+            event?.post(tap: CGEventTapLocation.cgSessionEventTap)
         } else {
             fatalError("Scrolling is only available on 10.13 or later\n")
         }
@@ -207,7 +207,7 @@ class MouseController {
             mouseEventSource: eventSource, mouseType: moveType, mouseCursorPosition: location,
             mouseButton: button ?? CGMouseButton.left)
         moveEvent?.flags = flags
-        moveEvent?.post(tap: CGEventTapLocation.cghidEventTap)
+        moveEvent?.post(tap: CGEventTapLocation.cgSessionEventTap)
     }
 
     private func getEventType(_ mouseType: mouseEventType, _ button: CGMouseButton? = nil) -> CGEventType {

--- a/Sources/SendKeysLib/MousePosition.swift
+++ b/Sources/SendKeysLib/MousePosition.swift
@@ -113,7 +113,7 @@ class MousePosition: ParsableCommand {
 
         guard
             let eventTap = CGEvent.tapCreate(
-                tap: .cghidEventTap, place: .tailAppendEventTap, options: .defaultTap,
+                tap: .cgSessionEventTap, place: .tailAppendEventTap, options: .defaultTap,
                 eventsOfInterest: CGEventMask(eventMask),
                 callback: {
                     (proxy: CGEventTapProxy, eventType: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?)

--- a/Sources/SendKeysLib/TerminationListener.swift
+++ b/Sources/SendKeysLib/TerminationListener.swift
@@ -42,7 +42,7 @@ class TerminationListener {
 
         guard
             let eventTap = CGEvent.tapCreate(
-                tap: .cghidEventTap, place: .tailAppendEventTap, options: .defaultTap,
+                tap: .cgSessionEventTap, place: .tailAppendEventTap, options: .defaultTap,
                 eventsOfInterest: CGEventMask(eventMask),
                 callback: {
                     (proxy: CGEventTapProxy, eventType: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?)


### PR DESCRIPTION
I've been using sendkeys to automate some testing inside VMs and discovered the following while trying to investigate why sendkeys "does nothing" in certain cases when I tried to employ multiple users in VM to benefit from some parallelization: basically it was _not_ TCC problem, it did not complain about lack of permissions/the "Terminal" and etc was added there. Basically for some users (typically, the first logged in) it worked, while for the rest it *silently* did nothing (except for activating the app that was set as the destination).

Spent quite several hours trying to figure it out, and then accidentally encountered the case that is captured on the recording: basically, sendkeys is sending mouse clicks to a _wrong_ user session. It turned out that it was matter of `.cghidEventTap` vs `.cgSessionEventTap`. That explains everything and fixes the problem for me (you can see the effect at the recording where /tmp/sendkeys is used - that's something compiled with the change).

The same problem is applicable to key presses (and is fixed as well).

(I did not try `.cgAnnotatedSessionEventTap` but I feel like `.cgSessionEventTap` does enough job.)


https://github.com/user-attachments/assets/8b8cf13d-016e-40a3-bc97-9826bb40359e

