### PR TITLE
Added --window option to target keypresses at a specific window.

### DIFF
--- a/Sources/SendKeysLib/Configuration/SendConfig.swift
+++ b/Sources/SendKeysLib/Configuration/SendConfig.swift
@@ -7,11 +7,12 @@ struct SendConfig: Codable {
     var remap: [String: String]?
     var targeted: Bool?
     var terminateCommand: String?
+    var window: String?
 
     init(
         activate: Bool? = nil, animationInterval: Double? = nil, delay: Double? = nil, initialDelay: Double? = nil,
         keyboardLayout: KeyMappings.Layouts? = nil, remap: [String: String]? = nil, targeted: Bool? = nil,
-        terminateCommand: String? = nil
+        terminateCommand: String? = nil, window: String? = nil
     ) {
         self.activate = activate
         self.animationInterval = animationInterval
@@ -21,6 +22,7 @@ struct SendConfig: Codable {
         self.remap = remap
         self.targeted = targeted
         self.terminateCommand = terminateCommand
+        self.window = window
     }
 
     func merge(with other: SendConfig?) -> SendConfig {


### PR DESCRIPTION
Here's a way of sending keypresses only to a specific window. It works by focusing the right window within the application before sending the keypresses. It may run into problems with apps that override window focus or event handling.

I've made the --window argument restrictive, so if it doesn't find a matching window it won't send the event.

It does a startsWith match instead of a complete match. My use case is for PowerPoint slide shows, and those windows are always titled "PowerPoint Slide Show – File Name.pptx", so this lets you do

`sendkeys send --targeted -a com.microsoft.Powerpoint --no-activate --window "PowerPoint Slide Show" -i 0 -c "<c:pgdown>"`
    